### PR TITLE
Fix input function name + typo

### DIFF
--- a/src/part2/objects.md
+++ b/src/part2/objects.md
@@ -124,7 +124,7 @@ Explaining why requires a more thorough explanation of the Game Boy's rendering,
 :::
 
 Now you should see the paddle moving... very quickly.
-Because it moves by a pixel ever frame, it's going at a speed of 60 pixels per second!
+Because it moves by a pixel every frame, it's going at a speed of 60 pixels per second!
 To slow this down, we'll use a *variable*.
 
 So far, we have only worked with the CPU registers, but you can create global variables too!

--- a/unbricked/collision/main.asm
+++ b/unbricked/collision/main.asm
@@ -205,7 +205,7 @@ PaddleBounceDone:
 ; ANCHOR_END: paddle-bounce
 
 	; Check the current keys every frame and move left or right.
-	call Input
+	call UpdateKeys
 
 	; First, check if the left button is pressed.
 CheckLeft:
@@ -291,7 +291,7 @@ IsWallTile:
 	ret
 ; ANCHOR_END: is-wall-tile
 
-Input:
+UpdateKeys:
   ; Poll half the controller
   ld a, P1F_GET_BTN
   call .onenibble

--- a/unbricked/input/input.asm
+++ b/unbricked/input/input.asm
@@ -6,9 +6,9 @@ SECTION "Input Variables", WRAM0
 wCurKeys: db
 wNewKeys: db
 
-SECTION "Input", ROM0
+SECTION "UpdateKeys", ROM0
 
-Input:
+UpdateKeys:
   ; Poll half the controller
   ld a, P1F_GET_BTN
   call .onenibble

--- a/unbricked/input/main.asm
+++ b/unbricked/input/main.asm
@@ -82,7 +82,7 @@ WaitVBlank2:
 	jp c, WaitVBlank2
 
 	; Check the current keys every frame and move left or right.
-	call Input
+	call UpdateKeys
 
 	; First, check if the left button is pressed.
 CheckLeft:
@@ -116,7 +116,7 @@ Right:
 ; ANCHOR_END: main
 
 ; ANCHOR: input-routine
-Input:
+UpdateKeys:
   ; Poll half the controller
   ld a, P1F_GET_BTN
   call .onenibble


### PR DESCRIPTION
I supposed the `UpdateKeys` routine got renamed into `Input` but the surrounding paragraphs don't seem to have been updated.