### PR TITLE
Fix link to gbdev wide contributing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution guidelines
 
-- Read the [gbdev wide](https://github.com/gbdev/meta/blob/master/CONTRIBUTING.md) contribution guidelines
+- Read the [gbdev wide](https://gbdev.io/contributing.html) contribution guidelines
 - Run an English spell checker
 - Try to split the PR in small, self-contained parts so they can be reviewed and merged faster (and independently)
 - Make sure the code you are adding/changing follows the [GB ASM Style guide](https://gbdev.io/guides/asmstyle.html)


### PR DESCRIPTION
This just fixes a broken link in CONTRIBUTING.md, to the gbdev org-wide contributing guidelines.

It looks like that document got moved to the website repo and this link didn't get updated.
*It may be worth scanning for other links to gbdev/meta in other files/repos.*

I pointed it to the gbdev.io html page, rather than the source file on github -- matching the style guide link further down.