### PR TITLE
objects main.asm fix.

### DIFF
--- a/unbricked/objects/main.asm
+++ b/unbricked/objects/main.asm
@@ -78,7 +78,7 @@ ClearOam:
 	ld [hli], a
 	ld a, 0
 	ld [hli], a
-	ld [hl], a
+	ld [hli], a
 ; ANCHOR_END: init-object
 
 ; ANCHOR: enable-oam


### PR DESCRIPTION
Later revisions in the collision tutorial correct this error to be ld [hli],a 
ld [hli],a 

If not present later during the ball movement code the paddle bounces around the screen instead.