### PR TITLE
Fix bit numbers in comment for the example input reading routine

### DIFF
--- a/unbricked/input/main.asm
+++ b/unbricked/input/main.asm
@@ -130,7 +130,7 @@ UpdateKeys:
   ; Poll the other half
   ld a, P1F_GET_DPAD
   call .onenibble
-  swap a ; A3-0 = unpressed directions; A7-4 = 1
+  swap a ; A7-4 = unpressed directions; A3-0 = 1
   xor a, b ; A = pressed buttons + directions
   ld b, a ; B = pressed buttons + directions
 


### PR DESCRIPTION
It looks like maybe the comment was copied from the one above for reading the buttons. If so, the order of the parts were swapped but not the bit numbers.