### PR TITLE
Prevent GitHub Pages deployment on forks

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -70,7 +70,7 @@ jobs:
   deploy:
     name: Deploy to GitHub pages
     # Do not run this unless *pushing* to `master`.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'gbdev/gb-asm-tutorial'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Closes https://github.com/gbdev/gb-asm-tutorial/issues/167

This PR adds a conditional check to the `build_and_deploy.yaml` workflow file to skip the deployment step when the workflow is triggered on a fork. This resolves the 404 errors seen on forked repositories by preventing the action from attempting to deploy to a non-existent GitHub Pages source. The check utilizes the `github.event_name` and `github.repository` context variables to determine if the workflow is running on a fork.